### PR TITLE
README.md: fixed redirect and wget for Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you're on a Mac you can download the zip file or clone the repo and use [pyth
 
 Or the following will work on a Mac too:
 
-    $ wget https://github.com/telegeography/www.submarinecablemap.com/archive/master.zip
+    $ curl https://codeload.github.com/telegeography/www.submarinecablemap.com/zip/master > master.zip
     $ unzip master.zip
     $ cd www.submarinecablemap.com-master/public/
     $ python -m SimpleHTTPServer


### PR DESCRIPTION
Recent OS X versions come without wget included. You will need to use curl to fetch the archive.

I also noticed that the original url `https://github.com/telegeography/www.submarinecablemap.com/archive/master.zip` redirects to `https://codeload.github.com/telegeography/www.submarinecablemap.com/zip/master` so I changed that as well.