### PR TITLE
Update the date to an international format

### DIFF
--- a/app/components/copyright-year.js
+++ b/app/components/copyright-year.js
@@ -8,6 +8,6 @@ export default Component.extend({
   didInsertElement(){
     this._super(...arguments);
     let application = getOwner(this).application;
-    $("#updated-on a").text(`Last updated on ${$.datepicker.formatDate("MM d, yy", new Date(application.mapConfig.creation_time))}`);
+    $("#updated-on a").text(`Last updated on ${$.datepicker.formatDate("d MM yy", new Date(application.mapConfig.creation_time))}`);
   }
 });


### PR DESCRIPTION
Being an international company, it doesn't make sense to use an
archaic and illogical (middle-endian) date format that is only
used in the US. As such, this commit updates the displayed date
format to the international long-form date format (RFC 2822) that
is standard in every other part of the world and in email messages
as well.